### PR TITLE
Add multi-round Tag Game (Roblox/Rojo)

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,0 +1,27 @@
+{
+  "name": "TagGame",
+  "tree": {
+    "$className": "DataModel",
+    "ReplicatedStorage": {
+      "$className": "ReplicatedStorage",
+      "GameConfig": {
+        "$path": "src/ReplicatedStorage/GameConfig.lua"
+      }
+    },
+    "ServerScriptService": {
+      "$className": "ServerScriptService",
+      "GameManager": {
+        "$path": "src/ServerScriptService/GameManager.server.lua"
+      }
+    },
+    "StarterPlayer": {
+      "$className": "StarterPlayer",
+      "StarterPlayerScripts": {
+        "$className": "StarterPlayerScripts",
+        "TagClient": {
+          "$path": "src/StarterPlayerScripts/TagClient.client.lua"
+        }
+      }
+    }
+  }
+}

--- a/src/ReplicatedStorage/GameConfig.lua
+++ b/src/ReplicatedStorage/GameConfig.lua
@@ -1,0 +1,16 @@
+-- GameConfig: Shared configuration for the Tag Game
+-- Loaded by both server (GameManager) and client (TagClient)
+return {
+    ROUND_COUNT         = 5,   -- total rounds per game
+    ROUND_DURATION      = 60,  -- seconds each round lasts
+    INTERMISSION_DELAY  = 10,  -- seconds between rounds
+    RESULTS_DISPLAY     = 6,   -- seconds to show round/game results
+    MIN_PLAYERS         = 2,   -- minimum players to start
+
+    IT_WALK_SPEED       = 22,  -- "It" player walk speed (default is 16)
+    NORMAL_WALK_SPEED   = 16,
+
+    TAG_IMMUNITY        = 2,   -- seconds of immunity after being tagged
+    POINTS_PER_SECOND   = 1,   -- points awarded to non-It players each second
+    ROUND_SURVIVAL_BONUS = 10, -- extra points for surviving an entire round without being It
+}

--- a/src/ServerScriptService/GameManager.server.lua
+++ b/src/ServerScriptService/GameManager.server.lua
@@ -1,0 +1,404 @@
+-- GameManager.server.lua
+-- Manages the full Tag Game loop: waiting, intermission, rounds, and scoring.
+--
+-- Game flow:
+--   Waiting → (enough players) → Intermission → InRound → RoundEnd
+--             ↑__________________________________↑  (repeat for ROUND_COUNT rounds)
+--   After all rounds → GameOver → restart
+
+local Players         = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local GameConfig = require(ReplicatedStorage:WaitForChild("GameConfig"))
+
+------------------------------------------------------------------------
+-- Remote events setup
+-- All events live in a folder in ReplicatedStorage so the client
+-- can WaitForChild them safely.
+------------------------------------------------------------------------
+local eventsFolder = Instance.new("Folder")
+eventsFolder.Name  = "TagEvents"
+eventsFolder.Parent = ReplicatedStorage
+
+-- Server → All clients: full game state snapshot
+local updateStateEvent = Instance.new("RemoteEvent")
+updateStateEvent.Name  = "UpdateState"
+updateStateEvent.Parent = eventsFolder
+
+-- Server → specific / all clients: toast notification text
+local notifyEvent  = Instance.new("RemoteEvent")
+notifyEvent.Name   = "Notify"
+notifyEvent.Parent = eventsFolder
+
+------------------------------------------------------------------------
+-- Game state (server-authoritative)
+------------------------------------------------------------------------
+local phase          = "Waiting"  -- Waiting|Intermission|InRound|RoundEnd|GameOver
+local currentRound   = 0
+local itPlayer       = nil        -- the current "It" Player object
+local scores         = {}         -- [Player] = cumulative integer score
+local tagCooldowns   = {}         -- [Player] = tick() at time of last tag
+local touchConns     = {}         -- active Touched connections on It's character
+
+------------------------------------------------------------------------
+-- Helpers
+------------------------------------------------------------------------
+local function alivePlayers()
+    return Players:GetPlayers()
+end
+
+local function getScore(p)
+    return scores[p] or 0
+end
+
+local function hasCooldown(p)
+    return tagCooldowns[p] ~= nil
+        and (tick() - tagCooldowns[p]) < GameConfig.TAG_IMMUNITY
+end
+
+local function buildPacket(timer)
+    local scoreTable = {}
+    for _, p in ipairs(alivePlayers()) do
+        scoreTable[p.Name] = getScore(p)
+    end
+    return {
+        phase       = phase,
+        round       = currentRound,
+        totalRounds = GameConfig.ROUND_COUNT,
+        itName      = itPlayer and itPlayer.Name or "",
+        timer       = math.max(0, math.ceil(timer or 0)),
+        scores      = scoreTable,
+    }
+end
+
+local function broadcast(timer)
+    updateStateEvent:FireAllClients(buildPacket(timer))
+end
+
+local function notify(msg, target)
+    if target then
+        notifyEvent:FireClient(target, msg)
+    else
+        notifyEvent:FireAllClients(msg)
+    end
+end
+
+------------------------------------------------------------------------
+-- Visual / stat helpers
+------------------------------------------------------------------------
+local function applyItLook(player, isIt)
+    local char = player.Character
+    if not char then return end
+
+    -- Walk speed
+    local hum = char:FindFirstChildOfClass("Humanoid")
+    if hum then
+        hum.WalkSpeed = isIt and GameConfig.IT_WALK_SPEED or GameConfig.NORMAL_WALK_SPEED
+    end
+
+    -- Red highlight when It
+    local existing = char:FindFirstChild("TagHighlight")
+    if isIt then
+        if not existing then
+            local hl = Instance.new("Highlight")
+            hl.Name             = "TagHighlight"
+            hl.FillColor        = Color3.fromRGB(220, 50, 50)
+            hl.OutlineColor     = Color3.fromRGB(255, 230, 0)
+            hl.FillTransparency = 0.45
+            hl.Parent           = char
+        end
+    else
+        if existing then existing:Destroy() end
+    end
+end
+
+------------------------------------------------------------------------
+-- Tag detection
+------------------------------------------------------------------------
+local function clearTouchConns()
+    for _, c in ipairs(touchConns) do c:Disconnect() end
+    touchConns = {}
+end
+
+-- Forward declaration so onTouched can reference it
+local transferIt
+
+local function onTouched(hit, taggerPlayer)
+    if phase ~= "InRound"        then return end
+    if taggerPlayer ~= itPlayer  then return end
+    if hasCooldown(taggerPlayer) then return end
+
+    local hitChar  = hit.Parent
+    local victim   = Players:GetPlayerFromCharacter(hitChar)
+
+    if not victim or victim == taggerPlayer then return end
+    if not victim.Character              then return end
+    if hasCooldown(victim)               then return end
+
+    transferIt(taggerPlayer, victim)
+end
+
+local function connectItTouched(player)
+    clearTouchConns()
+    local char = player.Character
+    if not char then return end
+
+    for _, part in ipairs(char:GetDescendants()) do
+        if part:IsA("BasePart") and part.Name ~= "HumanoidRootPart" then
+            local conn = part.Touched:Connect(function(hit)
+                onTouched(hit, player)
+            end)
+            table.insert(touchConns, conn)
+        end
+    end
+end
+
+-- Assign a new It player
+transferIt = function(oldIt, newIt)
+    -- Remove old It status
+    if oldIt and oldIt.Character then
+        applyItLook(oldIt, false)
+    end
+    tagCooldowns[oldIt] = tick()  -- brief immunity so they're not immediately re-tagged
+
+    -- Set new It
+    itPlayer = newIt
+    tagCooldowns[newIt] = tick()
+    applyItLook(newIt, true)
+    connectItTouched(newIt)
+
+    notify(string.format("🏃 %s tagged %s! %s is now IT!", oldIt.Name, newIt.Name, newIt.Name))
+    broadcast()
+end
+
+------------------------------------------------------------------------
+-- Round helpers
+------------------------------------------------------------------------
+local function pickRandom(list)
+    return list[math.random(1, #list)]
+end
+
+local function beginRound(timer)
+    broadcast(timer)
+end
+
+local function startRound()
+    local plist = alivePlayers()
+    if #plist < GameConfig.MIN_PLAYERS then
+        return false
+    end
+
+    currentRound = currentRound + 1
+    phase        = "InRound"
+
+    -- Clear all visuals first
+    for _, p in ipairs(plist) do
+        applyItLook(p, false)
+    end
+
+    -- Pick initial It
+    itPlayer = pickRandom(plist)
+    tagCooldowns[itPlayer] = tick()
+    applyItLook(itPlayer, true)
+    connectItTouched(itPlayer)
+
+    notify(string.format("⚡ Round %d/%d — %s is IT! RUN!", currentRound, GameConfig.ROUND_COUNT, itPlayer.Name))
+    notify("YOU ARE IT! Tag someone!", itPlayer)
+    broadcast(GameConfig.ROUND_DURATION)
+    return true
+end
+
+local function finishRound(neverItPlayers)
+    phase = "RoundEnd"
+    clearTouchConns()
+
+    -- Award survival bonus to everyone who was never It this round
+    for _, p in ipairs(neverItPlayers) do
+        if p and p.Parent then
+            scores[p] = getScore(p) + GameConfig.ROUND_SURVIVAL_BONUS
+        end
+    end
+
+    if itPlayer and itPlayer.Character then
+        applyItLook(itPlayer, false)
+    end
+    itPlayer = nil
+
+    notify(string.format("🔔 Round %d ended!", currentRound))
+    broadcast(0)
+end
+
+local function showGameOver()
+    phase = "GameOver"
+    clearTouchConns()
+
+    -- Find top scorer
+    local winner, topScore = nil, -1
+    for _, p in ipairs(alivePlayers()) do
+        local s = getScore(p)
+        if s > topScore then
+            topScore = s
+            winner   = p
+        end
+    end
+
+    if winner then
+        notify(string.format("🏆 Game Over! Winner: %s with %d points!", winner.Name, topScore))
+    else
+        notify("Game Over! No winner this time.")
+    end
+    broadcast(0)
+end
+
+------------------------------------------------------------------------
+-- Main game loop
+------------------------------------------------------------------------
+local function runGame()
+    -- Reset state
+    currentRound = 0
+    itPlayer     = nil
+    tagCooldowns = {}
+    scores       = {}
+    for _, p in ipairs(alivePlayers()) do
+        scores[p] = 0
+    end
+
+    for roundNum = 1, GameConfig.ROUND_COUNT do
+        ----------------------------------------------------------------
+        -- Intermission
+        ----------------------------------------------------------------
+        phase = "Intermission"
+        notify(string.format("⏳ Round %d/%d starts in %d seconds…",
+            roundNum, GameConfig.ROUND_COUNT, GameConfig.INTERMISSION_DELAY))
+
+        local intStart = tick()
+        repeat
+            local remaining = GameConfig.INTERMISSION_DELAY - (tick() - intStart)
+            broadcast(remaining)
+            task.wait(1)
+
+            -- Pause intermission if player count drops
+            if #alivePlayers() < GameConfig.MIN_PLAYERS then
+                phase = "Waiting"
+                notify("Not enough players — waiting…")
+                broadcast(0)
+                repeat task.wait(2) until #alivePlayers() >= GameConfig.MIN_PLAYERS
+                -- Restart intermission countdown
+                phase    = "Intermission"
+                intStart = tick()
+                notify(string.format("⏳ Round %d/%d starts in %d seconds…",
+                    roundNum, GameConfig.ROUND_COUNT, GameConfig.INTERMISSION_DELAY))
+            end
+        until (tick() - intStart) >= GameConfig.INTERMISSION_DELAY
+
+        ----------------------------------------------------------------
+        -- Round
+        ----------------------------------------------------------------
+        if not startRound() then
+            break
+        end
+
+        -- Track who was It during this round for survival bonus
+        local wasIt       = {}     -- set of players who were It at least once
+        local roundStart  = tick()
+
+        repeat
+            task.wait(1)
+
+            -- Award per-second survival points to non-It players
+            if itPlayer then
+                wasIt[itPlayer] = true
+                for _, p in ipairs(alivePlayers()) do
+                    if p ~= itPlayer then
+                        scores[p] = getScore(p) + GameConfig.POINTS_PER_SECOND
+                    end
+                end
+            end
+
+            local elapsed   = tick() - roundStart
+            local remaining = GameConfig.ROUND_DURATION - elapsed
+            broadcast(remaining)
+
+        until phase ~= "InRound" or (tick() - roundStart) >= GameConfig.ROUND_DURATION
+
+        -- Build list of players who were never It
+        local neverIt = {}
+        for _, p in ipairs(alivePlayers()) do
+            if not wasIt[p] then
+                table.insert(neverIt, p)
+            end
+        end
+
+        finishRound(neverIt)
+
+        -- Show results briefly
+        task.wait(GameConfig.RESULTS_DISPLAY)
+    end
+
+    ----------------------------------------------------------------
+    -- Game Over
+    ----------------------------------------------------------------
+    showGameOver()
+    task.wait(GameConfig.RESULTS_DISPLAY + 4)
+
+    -- Loop forever: restart
+    runGame()
+end
+
+------------------------------------------------------------------------
+-- Player lifecycle hooks
+------------------------------------------------------------------------
+Players.PlayerAdded:Connect(function(player)
+    scores[player] = scores[player] or 0
+
+    player.CharacterAdded:Connect(function(char)
+        -- Ensure correct walk speed on respawn
+        local hum = char:WaitForChild("Humanoid", 5)
+        if hum then
+            hum.WalkSpeed = GameConfig.NORMAL_WALK_SPEED
+        end
+
+        -- Re-apply It status after respawn
+        if player == itPlayer and phase == "InRound" then
+            task.delay(1, function()
+                applyItLook(player, true)
+                connectItTouched(player)
+            end)
+        end
+    end)
+end)
+
+Players.PlayerRemoving:Connect(function(player)
+    scores[player]       = nil
+    tagCooldowns[player] = nil
+
+    -- If the It player leaves, pick a new one immediately
+    if player == itPlayer and phase == "InRound" then
+        itPlayer = nil
+        local remaining = alivePlayers()
+        if #remaining >= 1 then
+            local newIt = pickRandom(remaining)
+            itPlayer = newIt
+            tagCooldowns[newIt] = tick()
+            applyItLook(newIt, true)
+            connectItTouched(newIt)
+            notify(string.format("The previous It left. %s is now IT!", newIt.Name))
+            broadcast()
+        end
+    end
+end)
+
+------------------------------------------------------------------------
+-- Boot
+------------------------------------------------------------------------
+task.spawn(function()
+    task.wait(2)  -- let the world load
+
+    phase = "Waiting"
+    broadcast(0)
+    notify(string.format("Waiting for %d players to join…", GameConfig.MIN_PLAYERS))
+
+    repeat task.wait(2) until #alivePlayers() >= GameConfig.MIN_PLAYERS
+
+    runGame()
+end)

--- a/src/StarterPlayerScripts/TagClient.client.lua
+++ b/src/StarterPlayerScripts/TagClient.client.lua
@@ -1,0 +1,420 @@
+-- TagClient.client.lua
+-- Builds and updates the in-game HUD for the Tag Game.
+--
+-- HUD layout:
+--   ┌─────────────────────────────────────────────────┐
+--   │  TOP BAR:  Round X/Y  │  Timer  │  IT: Name     │
+--   └─────────────────────────────────────────────────┘
+--   ┌──────────────────┐
+--   │  SCOREBOARD      │  (right side, always visible)
+--   │  1. Alice  - 123 │
+--   │  2. Bob    -  87 │
+--   └──────────────────┘
+--   NOTIFICATION TOAST (bottom-centre, fades out)
+
+local Players          = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local TweenService     = game:GetService("TweenService")
+
+local localPlayer = Players.LocalPlayer
+
+------------------------------------------------------------------------
+-- Wait for server events
+------------------------------------------------------------------------
+local eventsFolder  = ReplicatedStorage:WaitForChild("TagEvents", 10)
+local updateStateEv = eventsFolder:WaitForChild("UpdateState", 10)
+local notifyEv      = eventsFolder:WaitForChild("Notify", 10)
+
+------------------------------------------------------------------------
+-- Build ScreenGui
+------------------------------------------------------------------------
+local screenGui       = Instance.new("ScreenGui")
+screenGui.Name        = "TagHud"
+screenGui.ResetOnSpawn = false
+screenGui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
+screenGui.Parent      = localPlayer.PlayerGui
+
+-- ── colour palette ────────────────────────────────────────────────
+local C = {
+    bg        = Color3.fromRGB(20,  20,  30),
+    panel     = Color3.fromRGB(30,  30,  45),
+    accent    = Color3.fromRGB(255, 80,  80),
+    gold      = Color3.fromRGB(255, 220,  50),
+    white     = Color3.fromRGB(240, 240, 240),
+    dimWhite  = Color3.fromRGB(160, 160, 180),
+    green     = Color3.fromRGB(80,  220, 100),
+    transparent = Color3.fromRGB(0, 0, 0),
+}
+
+local function makePadding(frame, top, bot, left, right)
+    local p = Instance.new("UIPadding")
+    p.PaddingTop    = UDim.new(0, top or 0)
+    p.PaddingBottom = UDim.new(0, bot or 0)
+    p.PaddingLeft   = UDim.new(0, left or 0)
+    p.PaddingRight  = UDim.new(0, right or 0)
+    p.Parent = frame
+end
+
+local function makeCorner(frame, radius)
+    local c = Instance.new("UICorner")
+    c.CornerRadius = UDim.new(0, radius or 8)
+    c.Parent = frame
+end
+
+local function makeLabel(parent, name, text, size, bold, color)
+    local lbl = Instance.new("TextLabel")
+    lbl.Name            = name
+    lbl.Text            = text
+    lbl.TextSize        = size or 16
+    lbl.Font            = bold and Enum.Font.GothamBold or Enum.Font.Gotham
+    lbl.TextColor3      = color or C.white
+    lbl.BackgroundTransparency = 1
+    lbl.Size            = UDim2.new(1, 0, 1, 0)
+    lbl.TextXAlignment  = Enum.TextXAlignment.Center
+    lbl.TextYAlignment  = Enum.TextYAlignment.Center
+    lbl.Parent          = parent
+    return lbl
+end
+
+------------------------------------------------------------------------
+-- TOP BAR
+------------------------------------------------------------------------
+local topBar = Instance.new("Frame")
+topBar.Name            = "TopBar"
+topBar.Size            = UDim2.new(0.7, 0, 0, 48)
+topBar.Position        = UDim2.new(0.15, 0, 0, 8)
+topBar.BackgroundColor3 = C.panel
+topBar.BorderSizePixel  = 0
+topBar.Parent          = screenGui
+makeCorner(topBar, 10)
+
+-- Three equal columns inside top bar
+local topLayout = Instance.new("UIListLayout")
+topLayout.FillDirection = Enum.FillDirection.Horizontal
+topLayout.SortOrder     = Enum.SortOrder.LayoutOrder
+topLayout.HorizontalAlignment = Enum.HorizontalAlignment.Center
+topLayout.VerticalAlignment   = Enum.VerticalAlignment.Center
+topLayout.Parent = topBar
+
+local function topCell(name, order)
+    local cell = Instance.new("Frame")
+    cell.Name             = name
+    cell.Size             = UDim2.new(0.333, 0, 1, 0)
+    cell.BackgroundTransparency = 1
+    cell.LayoutOrder      = order
+    cell.Parent           = topBar
+    return cell
+end
+
+local roundCell  = topCell("RoundCell",  1)
+local timerCell  = topCell("TimerCell",  2)
+local itCell     = topCell("ItCell",     3)
+
+local roundLbl   = makeLabel(roundCell,  "RoundLbl",  "Round -/-",  15, true)
+local timerLbl   = makeLabel(timerCell,  "TimerLbl",  "0:00",       20, true, C.gold)
+local itLbl      = makeLabel(itCell,     "ItLbl",     "IT: —",      15, true, C.accent)
+
+-- Dividers between cells
+local function addDivider(parent, xPos)
+    local div = Instance.new("Frame")
+    div.Size              = UDim2.new(0, 1, 0.6, 0)
+    div.Position          = UDim2.new(xPos, 0, 0.2, 0)
+    div.BackgroundColor3  = C.dimWhite
+    div.BackgroundTransparency = 0.6
+    div.BorderSizePixel   = 0
+    div.Parent            = parent
+end
+addDivider(topBar, 0.333)
+addDivider(topBar, 0.666)
+
+------------------------------------------------------------------------
+-- "YOU ARE IT" banner (shown only when local player is It)
+------------------------------------------------------------------------
+local itBanner = Instance.new("TextLabel")
+itBanner.Name            = "ItBanner"
+itBanner.Size            = UDim2.new(0.5, 0, 0, 40)
+itBanner.Position        = UDim2.new(0.25, 0, 0, 62)
+itBanner.BackgroundColor3 = C.accent
+itBanner.BackgroundTransparency = 0.1
+itBanner.Text            = "⚡  YOU ARE IT!  TAG SOMEONE!"
+itBanner.TextColor3      = Color3.new(1, 1, 1)
+itBanner.Font            = Enum.Font.GothamBold
+itBanner.TextSize        = 18
+itBanner.BorderSizePixel  = 0
+itBanner.Visible          = false
+itBanner.Parent           = screenGui
+makeCorner(itBanner, 8)
+
+------------------------------------------------------------------------
+-- SCOREBOARD (right side)
+------------------------------------------------------------------------
+local scorePanel = Instance.new("Frame")
+scorePanel.Name            = "ScorePanel"
+scorePanel.Size            = UDim2.new(0, 190, 0, 220)
+scorePanel.Position        = UDim2.new(1, -200, 0.5, -110)
+scorePanel.BackgroundColor3 = C.panel
+scorePanel.BackgroundTransparency = 0.15
+scorePanel.BorderSizePixel  = 0
+scorePanel.Parent           = screenGui
+makeCorner(scorePanel, 10)
+makePadding(scorePanel, 8, 8, 10, 10)
+
+local scoreTitle = Instance.new("TextLabel")
+scoreTitle.Name            = "Title"
+scoreTitle.Size            = UDim2.new(1, 0, 0, 24)
+scoreTitle.Position        = UDim2.new(0, 0, 0, 0)
+scoreTitle.BackgroundTransparency = 1
+scoreTitle.Text            = "🏅  Scores"
+scoreTitle.TextColor3      = C.gold
+scoreTitle.Font            = Enum.Font.GothamBold
+scoreTitle.TextSize        = 16
+scoreTitle.TextXAlignment  = Enum.TextXAlignment.Left
+scoreTitle.Parent          = scorePanel
+
+local scoreList = Instance.new("ScrollingFrame")
+scoreList.Name             = "List"
+scoreList.Size             = UDim2.new(1, 0, 1, -28)
+scoreList.Position         = UDim2.new(0, 0, 0, 28)
+scoreList.BackgroundTransparency = 1
+scoreList.BorderSizePixel  = 0
+scoreList.ScrollBarThickness = 3
+scoreList.ScrollBarImageColor3 = C.dimWhite
+scoreList.Parent           = scorePanel
+
+local scoreListLayout = Instance.new("UIListLayout")
+scoreListLayout.SortOrder  = Enum.SortOrder.LayoutOrder
+scoreListLayout.Padding     = UDim.new(0, 3)
+scoreListLayout.Parent      = scoreList
+
+------------------------------------------------------------------------
+-- NOTIFICATION TOAST (bottom-centre)
+------------------------------------------------------------------------
+local toast = Instance.new("Frame")
+toast.Name             = "Toast"
+toast.Size             = UDim2.new(0.55, 0, 0, 44)
+toast.Position         = UDim2.new(0.225, 0, 1, -70)
+toast.BackgroundColor3  = C.bg
+toast.BackgroundTransparency = 0.15
+toast.BorderSizePixel   = 0
+toast.Visible           = false
+toast.Parent            = screenGui
+makeCorner(toast, 10)
+
+local toastLabel = Instance.new("TextLabel")
+toastLabel.Name           = "Msg"
+toastLabel.Size           = UDim2.new(1, -16, 1, 0)
+toastLabel.Position       = UDim2.new(0, 8, 0, 0)
+toastLabel.BackgroundTransparency = 1
+toastLabel.Text           = ""
+toastLabel.TextColor3     = C.white
+toastLabel.Font           = Enum.Font.Gotham
+toastLabel.TextSize       = 15
+toastLabel.TextWrapped    = true
+toastLabel.TextXAlignment = Enum.TextXAlignment.Center
+toastLabel.Parent         = toast
+
+------------------------------------------------------------------------
+-- PHASE OVERLAY (shown during Waiting / GameOver / RoundEnd)
+------------------------------------------------------------------------
+local overlay = Instance.new("Frame")
+overlay.Name             = "Overlay"
+overlay.Size             = UDim2.new(1, 0, 1, 0)
+overlay.BackgroundColor3  = Color3.new(0, 0, 0)
+overlay.BackgroundTransparency = 0.55
+overlay.Visible          = false
+overlay.ZIndex           = 5
+overlay.Parent           = screenGui
+
+local overlayTitle = Instance.new("TextLabel")
+overlayTitle.Name       = "Title"
+overlayTitle.Size       = UDim2.new(0.7, 0, 0, 60)
+overlayTitle.Position   = UDim2.new(0.15, 0, 0.35, 0)
+overlayTitle.BackgroundTransparency = 1
+overlayTitle.Text       = ""
+overlayTitle.TextColor3 = C.gold
+overlayTitle.Font       = Enum.Font.GothamBold
+overlayTitle.TextSize   = 36
+overlayTitle.ZIndex     = 6
+overlayTitle.Parent     = screenGui
+
+local overlayBody = Instance.new("TextLabel")
+overlayBody.Name        = "Body"
+overlayBody.Size        = UDim2.new(0.7, 0, 0, 40)
+overlayBody.Position    = UDim2.new(0.15, 0, 0.35 + 0.1, 0)
+overlayBody.BackgroundTransparency = 1
+overlayBody.Text        = ""
+overlayBody.TextColor3  = C.white
+overlayBody.Font        = Enum.Font.Gotham
+overlayBody.TextSize    = 20
+overlayBody.ZIndex      = 6
+overlayBody.Parent      = screenGui
+
+------------------------------------------------------------------------
+-- Toast notification helper
+------------------------------------------------------------------------
+local toastTween = nil
+
+local function showToast(msg)
+    if toastTween then toastTween:Cancel() end
+
+    toastLabel.Text          = msg
+    toast.BackgroundTransparency = 0.15
+    toastLabel.TextTransparency  = 0
+    toast.Visible = true
+
+    -- Fade out after 3.5 s
+    task.delay(3.5, function()
+        toastTween = TweenService:Create(toast,
+            TweenInfo.new(0.6, Enum.EasingStyle.Quad, Enum.EasingDirection.In),
+            { BackgroundTransparency = 1 })
+        local lblTween = TweenService:Create(toastLabel,
+            TweenInfo.new(0.6, Enum.EasingStyle.Quad, Enum.EasingDirection.In),
+            { TextTransparency = 1 })
+        toastTween:Play()
+        lblTween:Play()
+        toastTween.Completed:Connect(function()
+            toast.Visible = false
+        end)
+    end)
+end
+
+------------------------------------------------------------------------
+-- Format seconds → "M:SS"
+------------------------------------------------------------------------
+local function formatTime(secs)
+    secs = math.max(0, secs)
+    local m = math.floor(secs / 60)
+    local s = secs % 60
+    return string.format("%d:%02d", m, s)
+end
+
+------------------------------------------------------------------------
+-- Build / refresh the scoreboard rows
+------------------------------------------------------------------------
+local function refreshScoreboard(scoresData)
+    -- Sort names by score descending
+    local entries = {}
+    for name, pts in pairs(scoresData) do
+        table.insert(entries, { name = name, pts = pts })
+    end
+    table.sort(entries, function(a, b) return a.pts > b.pts end)
+
+    -- Remove old rows
+    for _, child in ipairs(scoreList:GetChildren()) do
+        if child:IsA("Frame") then child:Destroy() end
+    end
+
+    for i, entry in ipairs(entries) do
+        local row = Instance.new("Frame")
+        row.Name              = "Row_" .. i
+        row.Size              = UDim2.new(1, 0, 0, 22)
+        row.BackgroundTransparency = 1
+        row.LayoutOrder       = i
+        row.Parent            = scoreList
+
+        local nameLabel = Instance.new("TextLabel")
+        nameLabel.Size         = UDim2.new(0.65, 0, 1, 0)
+        nameLabel.Position     = UDim2.new(0, 0, 0, 0)
+        nameLabel.BackgroundTransparency = 1
+        nameLabel.Text         = string.format("%d. %s", i, entry.name)
+        nameLabel.TextColor3   = entry.name == localPlayer.Name and C.green or C.white
+        nameLabel.Font         = entry.name == localPlayer.Name
+            and Enum.Font.GothamBold or Enum.Font.Gotham
+        nameLabel.TextSize     = 14
+        nameLabel.TextXAlignment = Enum.TextXAlignment.Left
+        nameLabel.Parent       = row
+
+        local ptsLabel = Instance.new("TextLabel")
+        ptsLabel.Size          = UDim2.new(0.35, 0, 1, 0)
+        ptsLabel.Position      = UDim2.new(0.65, 0, 0, 0)
+        ptsLabel.BackgroundTransparency = 1
+        ptsLabel.Text          = tostring(entry.pts)
+        ptsLabel.TextColor3    = C.gold
+        ptsLabel.Font          = Enum.Font.GothamBold
+        ptsLabel.TextSize      = 14
+        ptsLabel.TextXAlignment = Enum.TextXAlignment.Right
+        ptsLabel.Parent        = row
+    end
+
+    -- Auto-size scroll frame
+    scoreList.CanvasSize = UDim2.new(0, 0, 0,
+        scoreListLayout.AbsoluteContentSize.Y + 4)
+end
+
+------------------------------------------------------------------------
+-- Main state update handler
+------------------------------------------------------------------------
+updateStateEvent.OnClientEvent:Connect(function(data)
+    local p     = data.phase       or "Waiting"
+    local round = data.round       or 0
+    local total = data.totalRounds or 0
+    local itName = data.itName     or ""
+    local timer  = data.timer      or 0
+
+    -- Top bar
+    roundLbl.Text = string.format("Round %d / %d", round, total)
+    timerLbl.Text = formatTime(timer)
+
+    if itName ~= "" then
+        itLbl.Text      = "IT: " .. itName
+        itLbl.TextColor3 = C.accent
+    else
+        itLbl.Text       = "IT: —"
+        itLbl.TextColor3  = C.dimWhite
+    end
+
+    -- Colour the timer red when under 10 s
+    timerLbl.TextColor3 = timer <= 10 and C.accent or C.gold
+
+    -- "You are It" banner
+    itBanner.Visible = (itName == localPlayer.Name) and (p == "InRound")
+
+    -- Scoreboard
+    if data.scores then
+        refreshScoreboard(data.scores)
+    end
+
+    -- Overlay / phase messaging
+    local showOverlay = false
+    local title, body = "", ""
+
+    if p == "Waiting" then
+        showOverlay = true
+        title = "Waiting for Players…"
+        body  = "Need at least 2 players to start"
+    elseif p == "Intermission" then
+        showOverlay = true
+        title = string.format("Round %d starting in…  %s", round + 1, formatTime(timer))
+        body  = "Get ready to run!"
+    elseif p == "RoundEnd" then
+        showOverlay = true
+        title = string.format("Round %d Over!", round)
+        body  = "Showing results…"
+    elseif p == "GameOver" then
+        showOverlay = true
+        title = "🏆  Game Over!"
+        -- Find winner from scores
+        local best, bestPts = "", -1
+        if data.scores then
+            for name, pts in pairs(data.scores) do
+                if pts > bestPts then bestPts = pts; best = name end
+            end
+        end
+        body = best ~= "" and string.format("Winner: %s  (%d pts)", best, bestPts) or ""
+    end
+
+    overlay.Visible      = showOverlay
+    overlayTitle.Visible = showOverlay
+    overlayBody.Visible  = showOverlay
+    if showOverlay then
+        overlayTitle.Text = title
+        overlayBody.Text  = body
+    end
+end)
+
+------------------------------------------------------------------------
+-- Notification handler
+------------------------------------------------------------------------
+notifyEv.OnClientEvent:Connect(function(msg)
+    showToast(msg)
+end)


### PR DESCRIPTION
Implements a complete Roblox tag game with:
- Configurable rounds (default 5 × 60 s) with intermission countdowns
- Server-authoritative tag detection via Touched events
- Per-second survival points + round-survival bonus scoring
- Red Highlight + speed boost for the "It" player
- Auto-reassignment when "It" player leaves mid-round
- HUD: top bar (round, timer, who's It), scoreboard, toast notifications
- Phase overlays for Waiting / Intermission / RoundEnd / GameOver

https://claude.ai/code/session_01LJjaLZMHty8psFYsc8bp2R